### PR TITLE
Fix uninitialized vars

### DIFF
--- a/integtest/socket_reader_test.py
+++ b/integtest/socket_reader_test.py
@@ -43,11 +43,15 @@ common_config_obj.config_db = (
     os.path.dirname(__file__) + "/../../daqsystemtest/config/daqsystemtest/example-configs.data.xml"
 )
 
-onebyone_local_socket_conf = copy.deepcopy(common_config_obj)
-onebyone_local_socket_conf.session = "local-socket-1x1-config"
+onebyone_local_crt_bern_conf = copy.deepcopy(common_config_obj)
+onebyone_local_crt_bern_conf.session = "local-crt-bern-1x1-config"
+
+onebyone_local_crt_grenoble_conf = copy.deepcopy(common_config_obj)
+onebyone_local_crt_grenoble_conf.session = "local-crt-grenoble-1x1-config"
 
 confgen_arguments = {
-    "Local Socket 1x1 Conf": onebyone_local_socket_conf,
+    "Local CRT Bern 1x1 Conf": onebyone_local_crt_bern_conf,
+    "Local CRT Grenoble 1x1 Conf": onebyone_local_crt_grenoble_conf,
 }
 
 nanorc_command_list = "boot conf".split()

--- a/plugins/SocketWriterModule.cpp
+++ b/plugins/SocketWriterModule.cpp
@@ -34,6 +34,7 @@ namespace dunedaq::asiolibs {
 SocketWriterModule::SocketWriterModule(const std::string& name)
   : DAQModule(name)
   , m_work_guard(boost::asio::make_work_guard(m_io_context))
+  , m_raw_receiver_timeout_ms(0)
 {
   register_command("conf", &SocketWriterModule::do_configure);
   register_command("start", &SocketWriterModule::do_start);
@@ -201,9 +202,6 @@ SocketWriterModule::run_consume()
       for (const auto& writer_config : m_writer_configs) {
         ++writer_config.socket_stats->rawq_timeout_count;
       }
-      // Protection against a zero sleep becoming a yield
-      if (m_raw_receiver_sleep_us != std::chrono::microseconds::zero())
-        std::this_thread::sleep_for(m_raw_receiver_sleep_us);
     }
   }
 

--- a/plugins/SocketWriterModule.cpp
+++ b/plugins/SocketWriterModule.cpp
@@ -34,7 +34,6 @@ namespace dunedaq::asiolibs {
 SocketWriterModule::SocketWriterModule(const std::string& name)
   : DAQModule(name)
   , m_work_guard(boost::asio::make_work_guard(m_io_context))
-  , m_raw_receiver_timeout_ms(0)
 {
   register_command("conf", &SocketWriterModule::do_configure);
   register_command("start", &SocketWriterModule::do_start);
@@ -74,7 +73,12 @@ SocketWriterModule::get_dal_inputs(const dunedaq::appmodel::SocketDataWriterModu
       }
 
       if (!m_callback_mode) {
-        m_raw_receiver_timeout_ms = std::chrono::milliseconds(input->get_recv_timeout_ms());
+        const auto recv_timeout_ms = input->get_recv_timeout_ms();
+        if (recv_timeout_ms == 0) {
+          TLOG() << "recv_timeout_ms is 0 or missing in the configuration. The default value " << m_raw_receiver_timeout_ms << " will be used.";
+        } else {
+          m_raw_receiver_timeout_ms = std::chrono::milliseconds(recv_timeout_ms);
+        }
       }
 
       auto* queue = input->cast<confmodel::QueueWithSourceId>();

--- a/plugins/SocketWriterModule.hpp
+++ b/plugins/SocketWriterModule.hpp
@@ -28,6 +28,11 @@ class SocketWriterModule : public dunedaq::appfwk::DAQModule
 {
 public:
   /**
+   * @brief Default raw data receiver timeout in ms
+   */
+  static constexpr auto raw_receiver_timeout_ms = 10;
+
+  /**
    * @brief SocketWriterModule constructor
    * @param name DAQ module instance name
    */
@@ -255,7 +260,7 @@ private:
   /**
    * @brief Raw data receiver timeout
    */  
-  std::chrono::milliseconds m_raw_receiver_timeout_ms;
+  std::chrono::milliseconds m_raw_receiver_timeout_ms{ raw_receiver_timeout_ms };
 
   /**
    * @brief Raw data receiver UID

--- a/plugins/SocketWriterModule.hpp
+++ b/plugins/SocketWriterModule.hpp
@@ -258,11 +258,6 @@ private:
   std::chrono::milliseconds m_raw_receiver_timeout_ms;
 
   /**
-   * @brief Raw data receiver sleep duration when there is no data
-   */  
-  std::chrono::microseconds m_raw_receiver_sleep_us;
-
-  /**
    * @brief Raw data receiver UID
    */  
   std::string m_raw_data_receiver_connection_name;  


### PR DESCRIPTION
- `m_raw_receiver_timeout_ms` is initialized in the constructor.
- `m_raw_receiver_sleep_us` is removed completely because there seems to be no point to it. In `DataHandlingModel` it is always set to 0 and only used when it is not 0. (??)