### PR TITLE
Removed several unneeded ignored_logfile_problems from the socket_reader_test.py

### DIFF
--- a/integtest/socket_reader_test.py
+++ b/integtest/socket_reader_test.py
@@ -22,16 +22,8 @@ check_for_logfile_errors = True
 hostname = os.uname().nodename
 
 ignored_logfile_problems = {
-    "-controller": [
-        "Worker with pid \\d+ was terminated due to signal 1",
-        "Connection '.*' not found on the application registry",
-    ],
-    "connectivity-service": [
-        "errorlog: -",
-    ],
     "local-connection-server": [
         "errorlog: -",
-        "Worker with pid \\d+ was terminated due to signal",
         r"Worker \(pid:\d+\) was sent SIGHUP"
     ],    
 }


### PR DESCRIPTION
I noticed that there are several ignored logfile problem strings listed in the `socket_reader_test` regression test.  Some of them are obsolete, and I have removed the obsolete ones in this Pull Request. 

To test these changes, I would suggest creating a software based on the latest nightly build, adding this repo to that software area, rebuilding the software area, and running the `socket_reader_test` using a command like `pytest -s socket_reader_test.py`.  If the test completes successfully, that will demonstrate that the removal of these ignored logfile problems hasn't hurt anything.