### PR TITLE
Minor change in SocketReaderModule.cpp to quiet a compiler warning.

### DIFF
--- a/plugins/SocketReaderModule.cpp
+++ b/plugins/SocketReaderModule.cpp
@@ -84,7 +84,7 @@ SocketReaderModule::init(const std::shared_ptr<appfwk::ConfigurationManager> mcf
   }
 
   for (auto* d2d_conn : d2d_conns) {
-    auto* socket_receiver = d2d_conn->get_net_receiver()->cast<appmodel::SocketReceiver>();
+    //auto* socket_receiver = d2d_conn->get_net_receiver()->cast<appmodel::SocketReceiver>();
 
     for (auto* sender : d2d_conn->get_net_senders()) {
       auto* socket_sender = sender->cast<appmodel::SocketDataSender>();

--- a/plugins/SocketReaderModule.cpp
+++ b/plugins/SocketReaderModule.cpp
@@ -84,8 +84,6 @@ SocketReaderModule::init(const std::shared_ptr<appfwk::ConfigurationManager> mcf
   }
 
   for (auto* d2d_conn : d2d_conns) {
-    //auto* socket_receiver = d2d_conn->get_net_receiver()->cast<appmodel::SocketReceiver>();
-
     for (auto* sender : d2d_conn->get_net_senders()) {
       auto* socket_sender = sender->cast<appmodel::SocketDataSender>();
 


### PR DESCRIPTION
It appears that the `socket_receiver` variable is not used anywhere after it is declared...