### PR TITLE
ASIO integtest with emu CRT configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# integtest temporary files
+__pycache__

--- a/integtest/socket_reader_test.py
+++ b/integtest/socket_reader_test.py
@@ -2,11 +2,7 @@ import pytest
 import os
 import re
 import copy
-import psutil
-import math
-import urllib.request
 
-import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
 
@@ -35,15 +31,18 @@ common_config_obj.config_db = (
     os.path.dirname(__file__) + "/../../daqsystemtest/config/daqsystemtest/example-configs.data.xml"
 )
 
-onebyone_local_crt_bern_conf = copy.deepcopy(common_config_obj)
-onebyone_local_crt_bern_conf.session = "local-crt-bern-1x1-config"
+onebyone_local_emu_crt_bern_conf = copy.deepcopy(common_config_obj)
+onebyone_local_emu_crt_bern_conf.session = "local-emu-crt-bern-1x1-config"
 
-onebyone_local_crt_grenoble_conf = copy.deepcopy(common_config_obj)
-onebyone_local_crt_grenoble_conf.session = "local-crt-grenoble-1x1-config"
+onebyone_local_emu_crt_grenoble_conf = copy.deepcopy(common_config_obj)
+onebyone_local_emu_crt_grenoble_conf.session = "local-emu-crt-grenoble-1x1-config"
+
+def host_is_at_ehn1(hostname):
+    return re.match(r"^(np02|np04)-srv-\d{3}$", hostname) or re.match(r"^(np02|np04)-srv-\d{3}.cern.ch$", hostname)
 
 confgen_arguments = {
-    "Local CRT Bern 1x1 Conf": onebyone_local_crt_bern_conf,
-    "Local CRT Grenoble 1x1 Conf": onebyone_local_crt_grenoble_conf,
+    "Local Emu CRT Bern 1x1 Conf": onebyone_local_emu_crt_bern_conf,
+    "Local Emu CRT Grenoble 1x1 Conf": onebyone_local_emu_crt_grenoble_conf,
 }
 
 nanorc_command_list = "boot conf".split()
@@ -56,7 +55,7 @@ nanorc_command_list += "scrap terminate".split()
 
 def test_nanorc_success(run_nanorc):
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    match_obj = re.search(r".*\[(.+)\].*", current_test)
+    match_obj = re.search(r".*\[(.+)-run_nanorc0\].*", current_test)
     if match_obj:
         current_test = match_obj.group(1)
     banner_line = re.sub(".", "=", current_test)
@@ -64,9 +63,9 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)    
 
-    if "cern.ch" not in hostname and "EHN1" in current_test:
+    if not host_is_at_ehn1(hostname) and "EHN1" in current_test:
         pytest.skip(
-            f"This computer ({hostname}) is not at CERN, not running EHN1 sessions"
+            f"This computer ({hostname}) is not at EHN1, not running EHN1 sessions"
         )
 
     # Check that nanorc completed correctly
@@ -75,9 +74,9 @@ def test_nanorc_success(run_nanorc):
 def test_log_files(run_nanorc):
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
 
-    if "cern.ch" not in hostname and "EHN1" in current_test:
+    if not host_is_at_ehn1(hostname) and "EHN1" in current_test:
         pytest.skip(
-            f"This computer ({hostname}) is not at CERN, not running EHN1 sessions"
+            f"This computer ({hostname}) is not at EHN1, not running EHN1 sessions"
         )
 
     if check_for_logfile_errors:

--- a/integtest/socket_reader_test.py
+++ b/integtest/socket_reader_test.py
@@ -24,14 +24,14 @@ bern_crt_frag_params = {
     "fragment_type": "CRTBern",
     "expected_fragment_count": number_of_data_producers,
     "min_size_bytes": 384,
-    "max_size_bytes": 488,
+    "max_size_bytes": 800,
 }
 grenoble_crt_frag_params = {
     "fragment_type_description": "CRTGrenoble",
     "fragment_type": "CRTGrenoble",
     "expected_fragment_count": number_of_data_producers,
     "min_size_bytes": 1752,
-    "max_size_bytes": 2312,
+    "max_size_bytes": 3992,
 }
 
 ignored_logfile_problems = {
@@ -44,6 +44,7 @@ ignored_logfile_problems = {
 common_config_obj = data_classes.drunc_config()
 common_config_obj.dro_map_config.n_streams = number_of_data_producers
 common_config_obj.dro_map_config.n_apps = number_of_readout_apps
+common_config_obj.op_env = "test"
 common_config_obj.config_db = (
     os.path.dirname(__file__) + "/../../daqsystemtest/config/daqsystemtest/example-configs.data.xml"
 )
@@ -105,9 +106,9 @@ def test_log_files(run_nanorc):
 def test_data_files(run_nanorc):
     fragment_check_list = []
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    if "BernCRT" in current_test:
+    if "Bern" in current_test:
         fragment_check_list.append(bern_crt_frag_params)
-    elif "GrenobleCRT" in current_test:
+    elif "Grenoble" in current_test:
         fragment_check_list.append(grenoble_crt_frag_params)
     # Run some tests on the output data file
     all_ok = True

--- a/integtest/socket_reader_test.py
+++ b/integtest/socket_reader_test.py
@@ -3,6 +3,7 @@ import os
 import re
 import copy
 
+import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
 
@@ -14,8 +15,24 @@ number_of_readout_apps = 1
 run_duration = 20  # seconds
 
 # Default values for validation parameters
+expected_number_of_data_files = 1
 check_for_logfile_errors = True
 hostname = os.uname().nodename
+
+bern_crt_frag_params = {
+    "fragment_type_description": "CRTBern",
+    "fragment_type": "CRTBern",
+    "expected_fragment_count": number_of_data_producers,
+    "min_size_bytes": 384,
+    "max_size_bytes": 488,
+}
+grenoble_crt_frag_params = {
+    "fragment_type_description": "CRTGrenoble",
+    "fragment_type": "CRTGrenoble",
+    "expected_fragment_count": number_of_data_producers,
+    "min_size_bytes": 1752,
+    "max_size_bytes": 2312,
+}
 
 ignored_logfile_problems = {
     "local-connection-server": [
@@ -84,3 +101,31 @@ def test_log_files(run_nanorc):
         assert log_file_checks.logs_are_error_free(
             run_nanorc.log_files, True, True, ignored_logfile_problems
         )
+
+def test_data_files(run_nanorc):
+    fragment_check_list = []
+    current_test = os.environ.get("PYTEST_CURRENT_TEST")
+    if "BernCRT" in current_test:
+        fragment_check_list.append(bern_crt_frag_params)
+    elif "GrenobleCRT" in current_test:
+        fragment_check_list.append(grenoble_crt_frag_params)
+    # Run some tests on the output data file
+    all_ok = True
+    all_ok &= len(run_nanorc.data_files) == expected_number_of_data_files
+    print("") # Clear potential dot from pytest
+    if all_ok:
+        print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
+    else:
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
+
+    for idx in range(len(run_nanorc.data_files)):
+        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+        for jdx in range(len(fragment_check_list)):
+            all_ok &= data_file_checks.check_fragment_count(
+                data_file, fragment_check_list[jdx]
+            )
+            all_ok &= data_file_checks.check_fragment_sizes(
+                data_file, fragment_check_list[jdx]
+            )
+
+    assert all_ok

--- a/plugins/SocketWriterModule.cpp
+++ b/plugins/SocketWriterModule.cpp
@@ -176,11 +176,8 @@ SocketWriterModule::run_consume()
   while (m_run_marker.load()) {
     // Try to acquire data
 
-    const auto opt_payload = m_raw_data_receiver->try_receive(m_raw_receiver_timeout_ms);
-
-    if (opt_payload) {
-      auto& payload = opt_payload.value();
-      consume_payload(payload);    
+    if (auto opt_payload = m_raw_data_receiver->try_receive(m_raw_receiver_timeout_ms)) {
+      consume_payload(std::move(*opt_payload));
     } else {
       for (const auto& writer_config : m_writer_configs) {
         ++writer_config.socket_stats->rawq_timeout_count;
@@ -192,12 +189,13 @@ SocketWriterModule::run_consume()
 }
 
 void
-SocketWriterModule::consume_payload(const std::pair<const void*, std::size_t>& payload)
+SocketWriterModule::consume_payload(GenericReceiverConcept::TypeErasedPayload payload)
 {
-    for (std::size_t i = 0; i < m_writers.size(); ++i) {
-      boost::asio::co_spawn(
-        m_io_context, std::visit([this, &payload](auto& writer) { return writer.start(payload); }, m_writers[i]), boost::asio::detached);
-    }  
+  for (auto& writer : m_writers) {
+    std::visit([this, payload](auto& w) mutable { // lets payload to be moved
+      boost::asio::co_spawn(m_io_context, w.start(std::move(payload)), boost::asio::detached);
+    }, writer);
+  }
 }
 
 void
@@ -210,7 +208,7 @@ SocketWriterModule::do_configure(const data_t&)
  
     // Register callback
     auto dmcbr = datahandlinglibs::DataMoveCallbackRegistry::get();
-    dmcbr->register_callback<std::pair<const void*, std::size_t>>(m_raw_data_receiver_connection_name, m_consume_callback);
+    dmcbr->register_callback<GenericReceiverConcept::TypeErasedPayload>(m_raw_data_receiver_connection_name, m_consume_callback);
   }
 
   for (std::size_t i = 0; i < m_writers.size(); ++i) {
@@ -301,10 +299,10 @@ SocketWriterModule::TCPWriter::configure(boost::asio::io_context& io_context, co
 }
 
 boost::asio::awaitable<void>
-SocketWriterModule::TCPWriter::start(const std::pair<const void*, std::size_t>& payload) // TODO (DTE): Rename
+SocketWriterModule::TCPWriter::start(GenericReceiverConcept::TypeErasedPayload payload) // TODO (DTE): Rename
 {
   const auto bytes_sent =
-    co_await m_socket->async_send(boost::asio::buffer(payload.first, payload.second), boost::asio::use_awaitable);
+    co_await boost::asio::async_write(*m_socket, boost::asio::buffer(payload.data, payload.size), boost::asio::use_awaitable);
   ++m_socket_stats->num_payloads;
   ++m_socket_stats->sum_payloads;
   m_socket_stats->sum_bytes.fetch_add(bytes_sent);
@@ -334,12 +332,12 @@ SocketWriterModule::UDPWriter::configure(boost::asio::io_context& io_context, co
 }
 
 boost::asio::awaitable<void>
-SocketWriterModule::UDPWriter::start(const std::pair<const void*, std::size_t>& payload)
+SocketWriterModule::UDPWriter::start(GenericReceiverConcept::TypeErasedPayload payload)
 {
   boost::asio::ip::udp::endpoint receiver_endpoint(boost::asio::ip::address::from_string(m_writer_config.remote_ip),
                                                    m_writer_config.remote_port);
   const auto bytes_sent = co_await m_socket->async_send_to(
-    boost::asio::buffer(payload.first, payload.second), receiver_endpoint, boost::asio::use_awaitable);
+      boost::asio::buffer(payload.data, payload.size), receiver_endpoint, boost::asio::use_awaitable);
   ++m_writer_config.socket_stats->num_payloads;
   ++m_writer_config.socket_stats->sum_payloads;
   m_writer_config.socket_stats->sum_bytes.fetch_add(bytes_sent);

--- a/plugins/SocketWriterModule.hpp
+++ b/plugins/SocketWriterModule.hpp
@@ -8,6 +8,8 @@
 #ifndef ASIOLIBS_PLUGINS_SOCKETWRITERMODULE_HPP_
 #define ASIOLIBS_PLUGINS_SOCKETWRITERMODULE_HPP_
 
+#include "GenericReceiverConcept.hpp"
+
 #include "appfwk/DAQModule.hpp"
 
 #include "appmodel/SocketDataWriterModule.hpp"
@@ -20,7 +22,6 @@
 
 namespace dunedaq::asiolibs {
 
-class GenericReceiverConcept;
 class ConfigurationManager;
 class SocketDataWriterModule;
 
@@ -127,7 +128,7 @@ private:
      * @param payload Payload to send
      * @return Coroutine handle
      */
-    boost::asio::awaitable<void> start(const std::pair<const void*, std::size_t>& payload);
+    boost::asio::awaitable<void> start(GenericReceiverConcept::TypeErasedPayload payload);
 
     /**
      * @brief Closes the socket
@@ -161,7 +162,7 @@ private:
      * @param payload Payload to send
      * @return Coroutine handle
      */
-    boost::asio::awaitable<void> start(const std::pair<const void*, std::size_t>& payload);
+    boost::asio::awaitable<void> start(GenericReceiverConcept::TypeErasedPayload payload);
 
     /**
      * @brief Closes the socket
@@ -209,7 +210,7 @@ private:
    * @brief Raw data consume callback function
    * @param payload Consumed data
    */  
-  void consume_payload(const std::pair<const void*, std::size_t>& payload);  
+  void consume_payload(GenericReceiverConcept::TypeErasedPayload payload);  
 
   /**
    * @brief I/O context for socket operations
@@ -282,7 +283,7 @@ private:
   /**
    * @brief Raw data consume callback
    */    
-  std::function<void(const std::pair<const void*, std::size_t>& payload)> m_consume_callback;  
+  std::function<void(GenericReceiverConcept::TypeErasedPayload payload)> m_consume_callback;  
 
   // RUN START T0
   /**

--- a/src/GenericReceiverConcept.hpp
+++ b/src/GenericReceiverConcept.hpp
@@ -15,8 +15,23 @@ namespace dunedaq::asiolibs {
 class GenericReceiverConcept
 {
 public: 
+    struct TypeErasedPayload {
+      /**
+       * @brief Keeps the payload's memory alive
+       */          
+      std::shared_ptr<const void> owner;
+      /**
+       * @brief Pointer to payload bytes
+       */     
+      const void* data;
+      /**
+       * @brief Number of bytes
+       */     
+      std::size_t size;
+    };
+
     virtual ~GenericReceiverConcept() = default;
-    virtual std::optional<std::pair<const void*, std::size_t>> try_receive(dunedaq::iomanager::Receiver::timeout_t timeout) = 0;
+    virtual std::optional<TypeErasedPayload> try_receive(dunedaq::iomanager::Receiver::timeout_t timeout) = 0;
 };   
 
 } // namespace dunedaq::asiolibs

--- a/src/GenericReceiverModel.hpp
+++ b/src/GenericReceiverModel.hpp
@@ -20,11 +20,13 @@ public:
     : m_receiver(get_iom_receiver<TargetPayloadType>(raw_data_receiver_connection_name))
   {}
 
-  std::optional<std::pair<const void*, std::size_t>> try_receive(dunedaq::iomanager::Receiver::timeout_t timeout) override {
+  std::optional<TypeErasedPayload> try_receive(dunedaq::iomanager::Receiver::timeout_t timeout) override {
     auto opt_payload = m_receiver->try_receive(timeout);
     if (opt_payload) {
-        m_received = std::move(*opt_payload);
-        return std::make_pair(&m_received, sizeof(TargetPayloadType));
+      // Allocate the received payload on the heap with shared ownership,
+      // so its lifetime can outlive this function and be tied to async sends.
+      auto payload = std::make_shared<TargetPayloadType>(std::move(*opt_payload));
+      return TypeErasedPayload{ std::reinterpret_pointer_cast<const void>(payload), payload.get(), sizeof(*payload) };
     }
     return std::nullopt;
   }
@@ -34,11 +36,6 @@ private:
    * @brief Generic IOManager Receiver
    */
   std::shared_ptr<iomanager::ReceiverConcept<TargetPayloadType>> m_receiver;
-
-  /**
-   * @brief Last received payload
-   */  
-  TargetPayloadType m_received;
 };
 
 } // namespace dunedaq::asiolibs


### PR DESCRIPTION
[Bug fix: Shared memory overwritten before send completes](https://github.com/DUNE-DAQ/asiolibs/pull/16/commits/0848889f1963a089cde0c7d63e8c33b2628b1428)

**Bug description:**

In _asiolibs/src/GenericReceiverModel.hpp_,
1. `try_receive` copies the newly received data into `m_received` and returns its address.
2. This address is then passed to `async_send_to`, which is:
    - Asynchronous - the actual send may occur at any point in the future.
    - Non-blocking - the function returns immediately, allowing the loop to continue receiving and overwriting `m_received`.

Now imagine we intend to send two frames, A and B:
1. We start an async send for A using the address of `m_received`.
2. Before that send actually transmits, we receive B and overwrite `m_received` with it.
3. We start another async send for B, also using `&m_received`.
4. When the first send finally runs, it reads from `m_received` (which now holds B) and sends B instead of A.
5. The second send also sends B.

**Result:** A is lost, and B is sent twice.

**Way to the solution:**

One question thay may arise: Why can't `try_receive` simply return the data it receives?
This is because the upstream `try_receive` returns, for example, `std::optional<CRTBernTypeAdapter>`, but the caller (`SocketWriterModule`) does not (and should not) need to know all data types it is sending.
This is why we need to return the data without exposing its type.

**Solution:**

Each `try_receive` allocates a new object on the heap for that specific frame, with its lifetime managed by a `shared_ptr`.
1. `try_receive` gives ownership to `SocketWriterModule::run_consume`.
2. `SocketWriterModule::run_consume` moves ownership to `SocketWriterModule::consume_payload`.
3. `SocketWriterModule::consume_payload` shares ownership with each writer (currently only 1).
4. Each writer moves ownership to `XWriter::start`.

The payload stays alive until the coroutine finishes.

----
[ASIO integtest with emu CRT configs](https://github.com/DUNE-DAQ/asiolibs/pull/16/commits/e6a6bd567b13ebea061bde340e4afae7a167785a)

Changed the integtest to run the new emu confs of CRT frames. The rest of the changes are taken from other integtests in `daqsystemtest`.

The following is the list of relevant branches (where `SkipListLatencyBufferModel` is used as the buffer type):
asiolibs: dte/asio_integtest
daqsystemtest: dte/emu_crt
appmodel: dte/fakereader_crt
fdreadoutlibs: dte/queue_for_crt
fdreadoutmodules: dte/queue_for_crt
crtmodules: dte/crt_integtest