### PR TITLE
Added a second drunc run to the socket_reader_test.py to verify that …

### DIFF
--- a/integtest/socket_reader_test.py
+++ b/integtest/socket_reader_test.py
@@ -16,7 +16,7 @@ number_of_readout_apps = 1
 run_duration = 20  # seconds
 
 # Default values for validation parameters
-expected_number_of_data_files = 1
+expected_number_of_data_files = 2
 check_for_logfile_errors = True
 hostname = os.uname().nodename
 
@@ -113,6 +113,9 @@ confgen_arguments = {
 nanorc_command_list = "boot conf".split()
 nanorc_command_list += (
     "start --run-number 101 wait 5 enable-triggers wait ".split()
+    + [str(run_duration)]
+    + "disable-triggers wait 1 drain-dataflow wait 2 stop-trigger-sources wait 1 stop wait 2".split()
+    + "start --run-number 102 wait 5 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 1 drain-dataflow wait 2 stop-trigger-sources wait 1 stop wait 2".split()
 )


### PR DESCRIPTION
…the underlying code can support multiple runs in a single DAQ session.

Note that this PR is still in a Draft state.  It should not be merged until the underlying `asiolibs` code is updated to support multiple runs in a single DAQ session.

# Description

It is a common feature of our integtest/regression tests that they take data twice (two runs).  The point of doing that is to verify that the underlying code can handle multiple runs in a single DAQ session.  I believe that the current `asiolibs` code does not support that, and running this modified version of the `socket_reader_test` demonstrates the problem.

The integtest can be run with `pytest -s socket_reader_test.py`.

Once the underlying code is updated, we can/should merge this change.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.

