### PR TITLE
Remove DataMoveCallbackRegistry, use IOManager direct callbacks instead

### DIFF
--- a/plugins/SocketReaderModule.cpp
+++ b/plugins/SocketReaderModule.cpp
@@ -140,18 +140,7 @@ SocketReaderModule::init(const std::shared_ptr<appfwk::ConfigurationManager> mcf
       throw err;
     }
 
-    // Check for CB prefix indicating Callback use
-    const char delim = '_';
-    const std::string target = queue->UID();
-    std::vector<std::string> words;
-    tokenize(target, delim, words);
-
-    bool callback_mode = false;
-    if (words.front() == "cb") {
-      callback_mode = true;
-    }
-
-    auto ptr = m_sources[queue->get_source_id()] = createSourceModel(queue->UID(), callback_mode);
+    auto ptr = m_sources[queue->get_source_id()] = createSourceModel(queue->UID());
     register_node(queue->UID(), ptr);
   }  
 }
@@ -179,11 +168,6 @@ SocketReaderModule::do_configure(const CommandData_t&)
 void
 SocketReaderModule::do_start(const CommandData_t&)
 {
-  // Setup callbacks on all sourcemodels
-  for (auto& [sourceid, source] : m_sources) {
-    source->acquire_callback();
-  }
-
   m_io_thread = std::jthread([this] { m_io_context.run(); });
 
   for (auto& reader : m_readers) {

--- a/plugins/SocketWriterModule.cpp
+++ b/plugins/SocketWriterModule.cpp
@@ -20,7 +20,6 @@
 #include "confmodel/QueueWithSourceId.hpp"
 
 #include "datahandlinglibs/DataHandlingIssues.hpp"
-#include "datahandlinglibs/DataMoveCallbackRegistry.hpp"
 
 #include "asiolibs/opmon/SocketWriterModule.pb.h"
 
@@ -207,8 +206,8 @@ SocketWriterModule::do_configure(const CommandData_t&)
     m_consume_callback = std::bind(&SocketWriterModule::consume_payload, this, std::placeholders::_1);
  
     // Register callback
-    auto dmcbr = datahandlinglibs::DataMoveCallbackRegistry::get();
-    dmcbr->register_callback<GenericReceiverConcept::TypeErasedPayload>(m_raw_data_receiver_connection_name, m_consume_callback);
+    auto dmcbr = iomanager::IOManager::get();
+    dmcbr->add_callback<GenericReceiverConcept::TypeErasedPayload>(m_raw_data_receiver_connection_name, m_consume_callback);
   }
 
   for (std::size_t i = 0; i < m_writers.size(); ++i) {

--- a/src/CreateSource.hpp
+++ b/src/CreateSource.hpp
@@ -30,7 +30,7 @@ DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::CRTGrenobleTypeAdapter, "CRTG
 namespace asiolibs {
 
 std::shared_ptr<SourceConcept>
-createSourceModel(const std::string& conn_uid, bool callback_mode)
+createSourceModel(const std::string& conn_uid)
 {
   auto datatypes = dunedaq::iomanager::IOManager::get()->get_datatypes(conn_uid);
   if (datatypes.size() != 1) {
@@ -49,7 +49,7 @@ createSourceModel(const std::string& conn_uid, bool callback_mode)
     source_model->set_sink_name(conn_uid);
 
     // Setup sink (acquire pointer from QueueRegistry)
-    source_model->set_sink(conn_uid, callback_mode);
+    source_model->set_sink(conn_uid);
 
     // Get parser and sink
     //auto& parser = source_model->get_parser();
@@ -70,19 +70,19 @@ createSourceModel(const std::string& conn_uid, bool callback_mode)
     // WIB2 specific char arrays
     auto source_model = std::make_shared<SourceModel<fdreadoutlibs::types::TDEFrameTypeAdapter>>();
     source_model->set_sink_name(conn_uid);
-    source_model->set_sink(conn_uid, callback_mode);
+    source_model->set_sink(conn_uid);
     //auto& parser = source_model->get_parser();
     //parser.process_chunk_func = parsers::fixsizedChunkInto<fdreadoutlibs::types::DUNEWIBSuperChunkTypeAdapter>(sink);
     return source_model;
   } else if (raw_dt.find("CRTBernFrame") != std::string::npos) {
     auto source_model = std::make_shared<SourceModel<fdreadoutlibs::types::CRTBernTypeAdapter>>();
     source_model->set_sink_name(conn_uid);
-    source_model->set_sink(conn_uid, callback_mode);
+    source_model->set_sink(conn_uid);
     return source_model;
   } else if (raw_dt.find("CRTGrenobleFrame") != std::string::npos) {
     auto source_model = std::make_shared<SourceModel<fdreadoutlibs::types::CRTGrenobleTypeAdapter>>();
     source_model->set_sink_name(conn_uid);
-    source_model->set_sink(conn_uid, callback_mode);
+    source_model->set_sink(conn_uid);
     return source_model;
   }
 

--- a/src/SourceConcept.hpp
+++ b/src/SourceConcept.hpp
@@ -38,8 +38,7 @@ namespace dunedaq {
       SourceConcept& operator=(SourceConcept&&) = delete;      ///< SourceConcept is not move-assignable
 
       //  virtual void init(const nlohmann::json& args) = 0;
-      virtual void set_sink(const std::string& sink_name, bool callback_mode) = 0;
-      virtual void acquire_callback() = 0;
+      virtual void set_sink(const std::string& sink_name) = 0;
       //  virtual void conf(const nlohmann::json& args) = 0;
       //  virtual void start(const nlohmann::json& args) = 0;
       //  virtual void stop(const nlohmann::json& args) = 0;

--- a/src/SourceModel.hpp
+++ b/src/SourceModel.hpp
@@ -18,7 +18,6 @@
 #include "asiolibs/opmon/SourceModel.pb.h"
 
 // #include "datahandlinglibs/utils/ReusableThread.hpp"
-#include "datahandlinglibs/DataMoveCallbackRegistry.hpp"
 #include "datahandlinglibs/utils/BufferCopy.hpp" 
 
 // #include <folly/ProducerConsumerQueue.h>
@@ -49,35 +48,15 @@ public:
   {}
   ~SourceModel() {}
 
-  void set_sink(const std::string& sink_name, bool callback_mode) override
+  void set_sink(const std::string& sink_name) override
   {
-    m_callback_mode = callback_mode;
-    if (callback_mode) {
-      TLOG_DEBUG(5) << "Callback mode requested. Won't acquire iom sender!";
-    } else {
       if (m_sink_is_set) {
         TLOG_DEBUG(5) << "SourceModel sink is already set in initialized!";
       } else {
         m_sink_queue = get_iom_sender<TargetPayloadType>(sink_name);
         m_sink_is_set = true;
       }
-    }
-  }
 
-  void acquire_callback() override
-  {
-    if (m_callback_mode) {
-      if (m_callback_is_acquired) {
-        TLOG_DEBUG(5) << "SourceModel callback is already acquired!";
-      } else {
-        // Getting DataMoveCBRegistry
-        auto dmcbr = datahandlinglibs::DataMoveCallbackRegistry::get();
-        m_sink_callback = dmcbr->get_callback<TargetPayloadType>(inherited::m_sink_name);
-        m_callback_is_acquired = true;
-      }
-    } else {
-      TLOG_DEBUG(5) << "Won't acquire callback, as IOM sink is set!";
-    }
   }
 
   std::shared_ptr<sink_t>& get_sink() { return m_sink_queue; }
@@ -89,16 +68,12 @@ public:
 
       TargetPayloadType& target_payload = *reinterpret_cast<TargetPayloadType*>(message);
   
-      if (m_callback_mode) {
-        (*m_sink_callback)(std::move(target_payload));
-      } else {
         if (!m_sink_queue->try_send(std::move(target_payload), iomanager::Sender::s_no_block)) {
           //if(m_dropped_packets == 0 || m_dropped_packets%10000) {
           //  TLOG() << "Dropped data " << m_dropped_packets;
           //}
           ++m_dropped_packets;
         }
-      }
 
     } else {
       TargetPayloadType target_payload;
@@ -127,12 +102,6 @@ private:
   std::string m_sink_id;
   bool m_sink_is_set{ false };
   std::shared_ptr<sink_t> m_sink_queue;
-
-  // Callback internals
-  bool m_callback_mode;
-  bool m_callback_is_acquired{ false };
-  using sink_cb_t = std::shared_ptr<std::function<void(TargetPayloadType&&)>>;
-  sink_cb_t m_sink_callback;
 
   std::atomic<uint64_t> m_dropped_packets{0};
 


### PR DESCRIPTION
# Description

See DUNE-DAQ/datahandlinglibs#119 for details. Requires DUNE-DAQ/iomanager#125


## Type of change

- [x] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

