### PR TITLE
Removed the stale and unneeded checking for tests at EHN1 in the integtest

### DIFF
--- a/integtest/socket_reader_test.py
+++ b/integtest/socket_reader_test.py
@@ -101,9 +101,6 @@ onebyone_local_emu_crt_grenoble_conf.config_substitutions.append(
     )
 )
 
-def host_is_at_ehn1(hostname):
-    return re.match(r"^(np02|np04)-srv-\d{3}$", hostname) or re.match(r"^(np02|np04)-srv-\d{3}.cern.ch$", hostname)
-
 confgen_arguments = {
     "Local Emu CRT Bern 1x1 Conf": onebyone_local_emu_crt_bern_conf,
     "Local Emu CRT Grenoble 1x1 Conf": onebyone_local_emu_crt_grenoble_conf,
@@ -127,22 +124,10 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)    
 
-    if not host_is_at_ehn1(hostname) and "EHN1" in current_test:
-        pytest.skip(
-            f"This computer ({hostname}) is not at EHN1, not running EHN1 sessions"
-        )
-
     # Check that nanorc completed correctly
     assert run_nanorc.completed_process.returncode == 0 
 
 def test_log_files(run_nanorc):
-    current_test = os.environ.get("PYTEST_CURRENT_TEST")
-
-    if not host_is_at_ehn1(hostname) and "EHN1" in current_test:
-        pytest.skip(
-            f"This computer ({hostname}) is not at EHN1, not running EHN1 sessions"
-        )
-
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(


### PR DESCRIPTION
# Description

While making other changes, I noticed that there was stale code in the integtest in this repo for checking whether it is being run at EHN1.  The changes in this PR remove the stale (and unneeded) code.

To test these changes, one would verify that the integtest continues to run successfully.

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] socket_reader_test passes
