### PR TITLE
Replaced the relative path to the daqsystemtest/example-configs.data.xml file.…

### DIFF
--- a/integtest/socket_reader_test.py
+++ b/integtest/socket_reader_test.py
@@ -46,7 +46,7 @@ common_config_obj.dro_map_config.n_streams = number_of_data_producers
 common_config_obj.dro_map_config.n_apps = number_of_readout_apps
 common_config_obj.op_env = "test"
 common_config_obj.config_db = (
-    os.path.dirname(__file__) + "/../../daqsystemtest/config/daqsystemtest/example-configs.data.xml"
+    os.environ.get("DAQSYSTEMTEST_SHARE") + "/config/daqsystemtest/example-configs.data.xml"
 )
 
 onebyone_local_emu_crt_bern_conf = copy.deepcopy(common_config_obj)

--- a/integtest/socket_reader_test.py
+++ b/integtest/socket_reader_test.py
@@ -45,6 +45,12 @@ common_config_obj = data_classes.drunc_config()
 common_config_obj.dro_map_config.n_streams = number_of_data_producers
 common_config_obj.dro_map_config.n_apps = number_of_readout_apps
 common_config_obj.op_env = "test"
+# 22-Jan-2026, KAB: added the use of the DAQSYSTEMTEST_SHARE env var as part of
+# specifying the location of the example-configs.data.xml file.  This is more
+# reliable than using a relative path to a parallel directory with the daqsystemtest
+# code in it.  Of course, this new model has the feature that users will need to
+# rebuild their software area if they make changes to the configuration entities
+# in a local copy of the daqsystemtest repo before this code will see those changes.
 common_config_obj.config_db = (
     os.environ.get("DAQSYSTEMTEST_SHARE") + "/config/daqsystemtest/example-configs.data.xml"
 )


### PR DESCRIPTION
…in the integtest with a path based on the DAQSYSTEMTEST_SHARE environmental variable.

# Description

I've noticed that we can't run the `asiolibs/integtest/socket_reader_test` from a base release.  But, it can be run from a local software area.

John pointed out that the location of the base configuration file was specified in the integtest using a relative path, which may or may not work outside of a local software area.

The change in this PR is to make use of the DAQSYSTEMTEST_SHARE env var instead of a relative path.

A good test of this change is to confirm that the integtest still works when the package is included in a local software area.  The true test of the change will come when we get a nightly build with this change included.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Full set of integration tests pass (`asiolibs_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
