### PR TITLE
Bump version to 1.3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(asiolibs VERSION 1.3.0)
+project(asiolibs VERSION 1.3.1)
 
 find_package(daq-cmake REQUIRED)
 


### PR DESCRIPTION
Bump version to 1.3.1

Brief summary of changes: Update `SocketReaderModule` to use confmodel's renamed `is_excluded()` accessor (was `is_disabled()`), per DUNE-DAQ/daq-deliverables#216.

> [!IMPORTANT]
> Tag `v1.3.1` has already been pushed and points at the head commit of this
> branch. **Please merge this PR with a merge commit — do not squash or rebase.**
> Squashing or rebasing would leave the published tag pointing at a commit that
> is not an ancestor of `prep-release/fddaq-v5.7.0`.
