### PR TITLE
Johnfreeman/merge in rc2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(asiolibs VERSION 1.3.0)
+project(asiolibs VERSION 1.3.1)
 
 find_package(daq-cmake REQUIRED)
 

--- a/plugins/SocketReaderModule.cpp
+++ b/plugins/SocketReaderModule.cpp
@@ -69,7 +69,7 @@ SocketReaderModule::init(const std::shared_ptr<appfwk::ConfigurationManager> mcf
   auto local_ip = nw_receiver->get_uses()->get_ip_address()[0];
 
   for (auto nw_sender : socket_d2d_conn->get_net_senders()) {
-    if (nw_sender->is_disabled(*(mcfg->get_session()))) {
+    if (nw_sender->is_excluded(*(mcfg->get_session()))) {
       continue;
     }
 
@@ -97,7 +97,7 @@ SocketReaderModule::init(const std::shared_ptr<appfwk::ConfigurationManager> mcf
 
     // Loop over streams
     for (auto det_stream : socket_sender->get_streams()) {
-      if (det_stream->is_disabled(*(mcfg->get_session()))) {
+      if (det_stream->is_excluded(*(mcfg->get_session()))) {
         continue;
       }
 


### PR DESCRIPTION
# Description

The `johnfreeman/merge_in_rc2` branch is a fork of `develop` from this morning (Sep 9) with this package's tagged code from `fddaq-v5.7.0-rc2-a9` merged in. It was part of a test build [`MRGFD_DEV_260909_A9`](https://github.com/DUNE-DAQ/daq-release/actions/runs/34370903745) which [successfully passed integration tests](https://github.com/DUNE-DAQ/daq-release/actions/runs/34378810212). This merge will de-facto bring the `fddaq-v5.7.0-rc2-a9` code into the nightly. 

_If full description and testing details are included on a parent issue, please link to that here._
See issue # for details

_Otherwise, please include a summary of the change and which issue is fixed (if any).
Include relevant motivation and context, including a target environment and dunedaq version if known.
Also list any dependencies that are required for this change._
Addresses issue # 

_Please also include instructions for how a reviewer can test your changes._


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

